### PR TITLE
Fix generator to emit ITextAlignment fluent extensions only when both…

### DIFF
--- a/src/FmgLib.MauiMarkup.Generator/Extensions/ExtensionGenerator.cs
+++ b/src/FmgLib.MauiMarkup.Generator/Extensions/ExtensionGenerator.cs
@@ -145,7 +145,7 @@ public static partial class {className}
                 GenerateEventMethod(@event);
             }
 
-            if (Helpers.IsBaseImplementationOfInterface(mainSymbol, "ITextAlignment"))
+            if (CanGenerateITextAlignmentExtensions())
                 GenerateExtensionMethods_ITextAlignment(mainSymbol);
         }
         else
@@ -157,6 +157,17 @@ public static partial class {className}
     bool IsEligibleProperty(IPropertySymbol property)
     {
         return property.DeclaredAccessibility == Accessibility.Public && !HasObsoleteAttribute(property);
+    }
+
+    bool CanGenerateITextAlignmentExtensions()
+    {
+        if (!Helpers.IsBaseImplementationOfInterface(mainSymbol, "ITextAlignment"))
+        {
+            return false;
+        }
+
+        return bindablePropertyNames.Any(name => name.Equals("VerticalTextAlignment", StringComparison.Ordinal))
+            && bindablePropertyNames.Any(name => name.Equals("HorizontalTextAlignment", StringComparison.Ordinal));
     }
 
     bool IsEligibleField(IFieldSymbol field)

--- a/src/FmgLib.MauiMarkup/FmgLib.MauiMarkup.csproj
+++ b/src/FmgLib.MauiMarkup/FmgLib.MauiMarkup.csproj
@@ -12,7 +12,7 @@
 		<PackageId>FmgLib.MauiMarkup</PackageId>
 		<Summary>FmgLib.MauiMarkup with C# Markup classes and fluent helper methods</Summary>
 		<Title>FmgLib.MauiMarkup</Title>
-		<Version>10.0.1-preview1</Version>
+		<Version>10.0.1-preview2</Version>
 		<Authors>FmgYazılım</Authors>
 		<Company>Fmg Yazılım</Company>
 		<Copyright>©2025</Copyright>

--- a/tests/FmgLib.MauiMarkup.Generator.Test/IntegrationTesting.cs
+++ b/tests/FmgLib.MauiMarkup.Generator.Test/IntegrationTesting.cs
@@ -134,6 +134,41 @@ public class FileName
         runResult.GeneratedTrees.Any(tree => tree.FilePath.Contains("SfAvatarView", StringComparison.OrdinalIgnoreCase)).Should().BeTrue();
     }
 
+    [Test]
+    public void TestSourceGenerator_AvatarView_DoesNotGenerateInvalidITextAlignmentPropertyAccess()
+    {
+        var rootPath = AppDomain.CurrentDomain.BaseDirectory;
+        var source = @"
+using CommunityToolkit.Maui.Views;
+using FmgLib.MauiMarkup;
+
+namespace ConsoleApp1;
+
+[MauiMarkup(typeof(AvatarView))]
+public class FileName
+{ }";
+
+        var additionalReferences = CreateSharedReferences(rootPath)
+            .Concat(new[]
+            {
+                @$"{rootPath}\DLLs\CommunityToolkit.Maui.Core.dll",
+                @$"{rootPath}\DLLs\CommunityToolkit.Maui.dll"
+            })
+            .ToArray();
+
+        var (compilation, _) = CreateCompilation(source, additionalReferences);
+
+        var generator = new SourceGenerator();
+        var driver = CreateDriver(generator);
+        driver = (CSharpGeneratorDriver)driver.RunGeneratorsAndUpdateCompilation(compilation, out var outputCompilation, out _);
+
+        var hasInvalidAlignmentPropertyError = outputCompilation
+            .GetDiagnostics()
+            .Any(d => d.Id == "CS0117" && d.GetMessage().Contains("TextAlignmentProperty"));
+
+        hasInvalidAlignmentPropertyError.Should().BeFalse();
+    }
+
     private static string[] CreateSharedReferences(string rootPath)
     {
         return


### PR DESCRIPTION
… text-alignment bindable properties exist